### PR TITLE
(SERVER-1408) Modify poms to support early release of jars

### DIFF
--- a/README-PUPPETLABS.md
+++ b/README-PUPPETLABS.md
@@ -1,0 +1,51 @@
+## Puppetlabs Fork of JRuby
+
+This branch contains some minor packaging changes that allow us to release jars
+for `jruby-stdlib` and `jruby-core`, independently from the upstream JRuby
+release cycle.  This was necessary in order to get access to some critical fixes
+that have been merged upstream but haven't yet been released.
+
+The files changed are:
+
+```
+./pom.xml
+./maven/pom.xml
+./maven/jruby-stdlib/pom.xml
+./core/pom.xml
+```
+
+The changes to those poms are limited to:
+
+* Changing the `groupId` to `puppetlabs` so that we can distinguish our artifacts.
+* Commenting out `modules` blocks, because we don't want the `mvn` tasks that we
+  run to bring in any of the other components, because we don't use them in our
+  builds.
+* Adding a `distributionManagement` section to each pom, so that we can specify
+  the maven artifact repository we'd like to deploy to.
+
+Technically we only really need to publish the `jruby-core` and `jruby-stdlib`
+jars, but because those have parent poms in the `org.jruby` namsepace (and because
+those parent poms will normally be versioned as SNAPSHOTs, and thus not yet
+available in public maven repositories), we need to release `puppetlabs` versions
+of those poms as well.
+
+At the time of this writing I haven't automated any of the release process; you'll
+need to manually update the version numbers in those 4 poms, set up your
+`~/.m2/settings.xml` to provide credentials for the target repository server,
+and then run `mvn deploy` from each of the 4 subdirectories in the appropriate
+order:
+
+```
+cd .
+mvn deploy
+cd maven
+mvn deploy
+cd ../core
+mvn deploy
+cd ../maven/jruby-stdlib
+mvn deploy
+```
+
+It's probably wise to make sure that you are running a JDK7 version of Java
+when you do this, just to be certain that you don't end up with any published
+jars that only work on JDK8.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # JRuby -  A Java implementation of the Ruby language
 
+NOTE: This branch from the puppetlabs fork includes some minor packaging
+ changes that allow us to release the jruby-core and jruby-stdlib jars
+ independently from the upstream JRuby release cycle.  For more info
+ see [README-PUPPETLABS.md](./README-PUPPETLABS.md)
+
 [![Build Status](https://travis-ci.org/jruby/jruby.png?branch=jruby-1_7)](https://travis-ci.org/jruby/jruby/branches)
 
 Authors: Stefan Matthias Aust, Anders Bengtsson, Geert Bevin,

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jruby</groupId>
+    <groupId>puppetlabs</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
   <artifactId>jruby-core</artifactId>
   <packaging>jar</packaging>
@@ -16,6 +16,45 @@
     <developerConnection>scm:git:ssh://git@github.com/jruby/jruby.git</developerConnection>
     <url>http://github.com/jruby/jruby</url>
   </scm>
+
+  <!-- __________________________________________________________________________________________ -->
+  <!-- begin custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
+  <!-- __________________________________________________________________________________________ -->
+
+  <!-- NOTE: to use any of the following you'll need to set up credentials for the
+       appropriate servers in ~/.m2/settings.xml -->
+
+  <!-- this setup would allow us to deploy to private nexus, but that would break OSS CI jobs -->
+  <!--<distributionManagement>-->
+    <!--<snapshotRepository>-->
+      <!--<id>pl-nexus-snapshots</id>-->
+      <!--<name>PL Nexus Snapshots</name>-->
+      <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
+    <!--</snapshotRepository>-->
+    <!--<repository>-->
+      <!--<id>pl-nexus-releases</id>-->
+      <!--<name>PL Nexus Releases</name>-->
+      <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
+    <!--</repository>-->
+  <!--</distributionManagement>-->
+
+  <!-- this setup deploys to clojars, which is publicly available -->
+  <distributionManagement>
+    <snapshotRepository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </snapshotRepository>
+    <repository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </repository>
+  </distributionManagement>
+
+  <!-- __________________________________________________________________________________________ -->
+  <!-- end custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
+  <!-- __________________________________________________________________________________________ -->
 
   <dependencies>
     <dependency>

--- a/maven/jruby-stdlib/pom.xml
+++ b/maven/jruby-stdlib/pom.xml
@@ -3,9 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jruby</groupId>
+    <groupId>puppetlabs</groupId>
     <artifactId>jruby-artifacts</artifactId>
-    <version>1.7.26-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
   <artifactId>jruby-stdlib</artifactId>
   <name>JRuby Stdlib</name>
@@ -21,6 +21,46 @@
     <tesla.dump.readonly>true</tesla.dump.readonly>
     <jruby.home>${basedir}/../..</jruby.home>
   </properties>
+
+  <!-- __________________________________________________________________________________________ -->
+  <!-- begin custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
+  <!-- __________________________________________________________________________________________ -->
+
+  <!-- NOTE: to use any of the following you'll need to set up credentials for the
+       appropriate servers in ~/.m2/settings.xml -->
+
+  <!-- this setup would allow us to deploy to private nexus, but that would break OSS CI jobs -->
+  <!--<distributionManagement>-->
+  <!--<snapshotRepository>-->
+  <!--<id>pl-nexus-snapshots</id>-->
+  <!--<name>PL Nexus Snapshots</name>-->
+  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
+  <!--</snapshotRepository>-->
+  <!--<repository>-->
+  <!--<id>pl-nexus-releases</id>-->
+  <!--<name>PL Nexus Releases</name>-->
+  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
+  <!--</repository>-->
+  <!--</distributionManagement>-->
+
+  <!-- this setup deploys to clojars, which is publicly available -->
+  <distributionManagement>
+    <snapshotRepository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </snapshotRepository>
+    <repository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </repository>
+  </distributionManagement>
+
+  <!-- __________________________________________________________________________________________ -->
+  <!-- end custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
+  <!-- __________________________________________________________________________________________ -->
+
   <build>
     <resources>
       <resource>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -3,13 +3,53 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jruby</groupId>
+    <groupId>puppetlabs</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
   <artifactId>jruby-artifacts</artifactId>
   <packaging>pom</packaging>
   <name>JRuby Artifacts</name>
+
+  <!-- __________________________________________________________________________________________ -->
+  <!-- begin custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
+  <!-- __________________________________________________________________________________________ -->
+
+  <!-- NOTE: to use any of the following you'll need to set up credentials for the
+       appropriate servers in ~/.m2/settings.xml -->
+
+  <!-- this setup would allow us to deploy to private nexus, but that would break OSS CI jobs -->
+  <!--<distributionManagement>-->
+  <!--<snapshotRepository>-->
+  <!--<id>pl-nexus-snapshots</id>-->
+  <!--<name>PL Nexus Snapshots</name>-->
+  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
+  <!--</snapshotRepository>-->
+  <!--<repository>-->
+  <!--<id>pl-nexus-releases</id>-->
+  <!--<name>PL Nexus Releases</name>-->
+  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
+  <!--</repository>-->
+  <!--</distributionManagement>-->
+
+  <!-- this setup deploys to clojars, which is publicly available -->
+  <distributionManagement>
+    <snapshotRepository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </snapshotRepository>
+    <repository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </repository>
+  </distributionManagement>
+
+  <!-- __________________________________________________________________________________________ -->
+  <!-- end custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
+  <!-- __________________________________________________________________________________________ -->
+
   <properties>
     <tesla.dump.readonly>true</tesla.dump.readonly>
     <tesla.dump.pom>pom.xml</tesla.dump.pom>
@@ -46,79 +86,79 @@
     </pluginManagement>
   </build>
   <profiles>
-    <profile>
-      <id>all</id>
-      <modules>
-        <module>jruby</module>
-        <module>jruby-noasm</module>
-        <module>jruby-stdlib</module>
-        <module>jruby-complete</module>
-        <module>jruby-dist</module>
-        <module>jruby-jars</module>
-        <module>jruby-rake-plugin</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>release</id>
-      <modules>
-        <module>jruby</module>
-        <module>jruby-noasm</module>
-        <module>jruby-stdlib</module>
-        <module>jruby-complete</module>
-        <module>jruby-dist</module>
-        <module>jruby-jars</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>main</id>
-      <modules>
-        <module>jruby</module>
-        <module>jruby-noasm</module>
-        <module>jruby-stdlib</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>osgi</id>
-      <modules>
-        <module>jruby</module>
-        <module>jruby-noasm</module>
-        <module>jruby-stdlib</module>
-        <module>jruby-complete</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>j2ee</id>
-      <modules>
-        <module>jruby</module>
-        <module>jruby-stdlib</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>complete</id>
-      <modules>
-        <module>jruby-stdlib</module>
-        <module>jruby-complete</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>dist</id>
-      <modules>
-        <module>jruby-stdlib</module>
-        <module>jruby-dist</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>jruby-jars</id>
-      <modules>
-        <module>jruby-stdlib</module>
-        <module>jruby-jars</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>jruby-rake-plugin</id>
-      <modules>
-        <module>jruby-rake-plugin</module>
-      </modules>
-    </profile>
+    <!--<profile>-->
+      <!--<id>all</id>-->
+      <!--<modules>-->
+        <!--<module>jruby</module>-->
+        <!--<module>jruby-noasm</module>-->
+        <!--<module>jruby-stdlib</module>-->
+        <!--<module>jruby-complete</module>-->
+        <!--<module>jruby-dist</module>-->
+        <!--<module>jruby-jars</module>-->
+        <!--<module>jruby-rake-plugin</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>release</id>-->
+      <!--<modules>-->
+        <!--<module>jruby</module>-->
+        <!--<module>jruby-noasm</module>-->
+        <!--<module>jruby-stdlib</module>-->
+        <!--<module>jruby-complete</module>-->
+        <!--<module>jruby-dist</module>-->
+        <!--<module>jruby-jars</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>main</id>-->
+      <!--<modules>-->
+        <!--<module>jruby</module>-->
+        <!--<module>jruby-noasm</module>-->
+        <!--<module>jruby-stdlib</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>osgi</id>-->
+      <!--<modules>-->
+        <!--<module>jruby</module>-->
+        <!--<module>jruby-noasm</module>-->
+        <!--<module>jruby-stdlib</module>-->
+        <!--<module>jruby-complete</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>j2ee</id>-->
+      <!--<modules>-->
+        <!--<module>jruby</module>-->
+        <!--<module>jruby-stdlib</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>complete</id>-->
+      <!--<modules>-->
+        <!--<module>jruby-stdlib</module>-->
+        <!--<module>jruby-complete</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>dist</id>-->
+      <!--<modules>-->
+        <!--<module>jruby-stdlib</module>-->
+        <!--<module>jruby-dist</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>jruby-jars</id>-->
+      <!--<modules>-->
+        <!--<module>jruby-stdlib</module>-->
+        <!--<module>jruby-jars</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>jruby-rake-plugin</id>-->
+      <!--<modules>-->
+        <!--<module>jruby-rake-plugin</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,52 @@
     <version>7</version>
   </parent>
 
-  <groupId>org.jruby</groupId>
+  <groupId>puppetlabs</groupId>
   <artifactId>jruby-parent</artifactId>
-  <version>1.7.26-SNAPSHOT</version>
+  <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>JRuby</name>
+
+  <!-- __________________________________________________________________________________________ -->
+  <!-- begin custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
+  <!-- __________________________________________________________________________________________ -->
+
+  <!-- NOTE: to use any of the following you'll need to set up credentials for the
+       appropriate servers in ~/.m2/settings.xml -->
+
+  <!-- this setup would allow us to deploy to private nexus, but that would break OSS CI jobs -->
+  <!--<distributionManagement>-->
+  <!--<snapshotRepository>-->
+  <!--<id>pl-nexus-snapshots</id>-->
+  <!--<name>PL Nexus Snapshots</name>-->
+  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
+  <!--</snapshotRepository>-->
+  <!--<repository>-->
+  <!--<id>pl-nexus-releases</id>-->
+  <!--<name>PL Nexus Releases</name>-->
+  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
+  <!--</repository>-->
+  <!--</distributionManagement>-->
+
+  <!-- this setup deploys to clojars, which is publicly available -->
+  <distributionManagement>
+    <snapshotRepository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </snapshotRepository>
+    <repository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </repository>
+  </distributionManagement>
+
+  <!-- __________________________________________________________________________________________ -->
+  <!-- end custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
+  <!-- __________________________________________________________________________________________ -->
+
 
   <repositories>
     <repository>
@@ -29,11 +69,11 @@
     </repository>
   </repositories>
 
-  <modules>
-    <module>ext</module>
-    <module>core</module>
-    <module>lib</module>
-  </modules>
+  <!--<modules>-->
+    <!--<module>ext</module>-->
+    <!--<module>core</module>-->
+    <!--<module>lib</module>-->
+  <!--</modules>-->
 
   <description>
     JRuby is the effort to recreate the Ruby (http://www.ruby-lang.org) interpreter in Java.
@@ -177,13 +217,13 @@
     <url>https://github.com/jruby/jruby/issues</url>
   </issueManagement>
 
-  <distributionManagement>
-    <site>
-      <id>gh-pages</id>
-      <name>JRuby Site</name>
-      <url>https://github.com/jruby/jruby</url>
-    </site>
-  </distributionManagement>
+  <!--<distributionManagement>-->
+    <!--<site>-->
+      <!--<id>gh-pages</id>-->
+      <!--<name>JRuby Site</name>-->
+      <!--<url>https://github.com/jruby/jruby</url>-->
+    <!--</site>-->
+  <!--</distributionManagement>-->
 
   <pluginRepositories>
     <pluginRepository>
@@ -437,203 +477,203 @@
   </dependencyManagement>
 
   <profiles>
-    <profile>
-      <id>bootstrap</id>
-      <modules>
-        <module>test</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>test</id>
-      <properties>
-	<invoker.skip>false</invoker.skip>
-      </properties>
-      <modules>
-        <module>test</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>gems</id>
-      <modules>
-        <module>maven</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>docs</id>
-      <modules>
-        <module>docs</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>main</id>
-      <modules>
-        <module>maven</module>
-      </modules>
-      <build>
-	<defaultGoal>install</defaultGoal>
-	<pluginManagement>
-	  <plugins>
-            <plugin>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.15</version>
-	      <configuration>
-		<skipTests>true</skipTests>
-	      </configuration>
-            </plugin>
-	  </plugins>
-	</pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <id>osgi</id>
-      <modules>
-        <module>maven</module>
-      </modules>
-      <properties>
-	<invoker.skip>false</invoker.skip>
-	<its.osgi>no-excludes/pom.xml</its.osgi>
-      </properties>
-      <build>
-	<defaultGoal>install</defaultGoal>
-	<plugins>
-          <plugin>
-            <artifactId>maven-invoker-plugin</artifactId>
-            <configuration>
-              <pomIncludes>
-                <pomInclude>osgi*/pom.xml</pomInclude>
-	      </pomIncludes>
-	    </configuration>
-	  </plugin>
-	</plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>j2ee</id>
-      <modules>
-        <module>maven</module>
-      </modules>
-      <properties>
-	<invoker.skip>false</invoker.skip>
-	<its.j2ee>no-excludes/pom.xml</its.j2ee>
-      </properties>
-      <build>
-	<defaultGoal>install</defaultGoal>
-	<plugins>
-          <plugin>
-            <artifactId>maven-invoker-plugin</artifactId>
-            <configuration>
-              <pomIncludes>
-                <pomInclude>j2ee*/pom.xml</pomInclude>
-	      </pomIncludes>
-	    </configuration>
-	  </plugin>
-	</plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>single invoker test</id>
-      <activation>
-        <property>
-          <name>invoker.test</name>
-	</property>
-      </activation>
-      <properties>
-	<invoker.skip>false</invoker.skip>
-      </properties>
-    </profile>
-    <profile>
-      <id>jruby-jars</id>
-      <modules>
-        <module>maven</module>
-      </modules>
-      <build>
-	<defaultGoal>install</defaultGoal>
-	<pluginManagement>
-	  <plugins>
-            <plugin>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.15</version>
-	      <configuration>
-		<skipTests>true</skipTests>
-	      </configuration>
-            </plugin>
-	  </plugins>
-	</pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <id>complete</id>
-      <modules>
-        <module>maven</module>
-      </modules>
-      <build>
-	<defaultGoal>install</defaultGoal>
-	<pluginManagement>
-	  <plugins>
-            <plugin>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.15</version>
-	      <configuration>
-		<skipTests>true</skipTests>
-	      </configuration>
-            </plugin>
-	  </plugins>
-	</pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <id>rake-plugin</id>
-      <modules>
-        <module>maven</module>
-      </modules>
-      <build>
-	<defaultGoal>install</defaultGoal>
-      </build>
-    </profile>
-    <profile>
-      <id>dist</id>
-      <modules>
-        <module>maven</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>all</id>
-      <modules>
-	<module>test</module>
-        <module>docs</module>
-        <module>maven</module>
-      </modules>
-      <build>
-	<defaultGoal>install</defaultGoal>
-      </build>
-    </profile>
-    <profile>
-      <id>release</id>
-      <modules>
-        <module>maven</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>snapshots</id>
-      <activation>
-        <file>
-          <exists>/builds/snapshots</exists>
-        </file>
-      </activation>
-      <build>
-        <defaultGoal>deploy</defaultGoal>
-      </build>
-      <distributionManagement>
-        <repository>
-          <id>local releases</id>
-          <url>file:/builds/snapshots/maven</url>
-        </repository>
-        <snapshotRepository>
-          <id>local snapshots</id>
-          <url>file:/builds/snapshots/maven</url>
-        </snapshotRepository>
-      </distributionManagement>
-    </profile>
+    <!--<profile>-->
+      <!--<id>bootstrap</id>-->
+      <!--<modules>-->
+        <!--<module>test</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>test</id>-->
+      <!--<properties>-->
+	<!--<invoker.skip>false</invoker.skip>-->
+      <!--</properties>-->
+      <!--<modules>-->
+        <!--<module>test</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>gems</id>-->
+      <!--<modules>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>docs</id>-->
+      <!--<modules>-->
+        <!--<module>docs</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>main</id>-->
+      <!--<modules>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+      <!--<build>-->
+	<!--<defaultGoal>install</defaultGoal>-->
+	<!--<pluginManagement>-->
+	  <!--<plugins>-->
+            <!--<plugin>-->
+              <!--<artifactId>maven-surefire-plugin</artifactId>-->
+              <!--<version>2.15</version>-->
+	      <!--<configuration>-->
+		<!--<skipTests>true</skipTests>-->
+	      <!--</configuration>-->
+            <!--</plugin>-->
+	  <!--</plugins>-->
+	<!--</pluginManagement>-->
+      <!--</build>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>osgi</id>-->
+      <!--<modules>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+      <!--<properties>-->
+	<!--<invoker.skip>false</invoker.skip>-->
+	<!--<its.osgi>no-excludes/pom.xml</its.osgi>-->
+      <!--</properties>-->
+      <!--<build>-->
+	<!--<defaultGoal>install</defaultGoal>-->
+	<!--<plugins>-->
+          <!--<plugin>-->
+            <!--<artifactId>maven-invoker-plugin</artifactId>-->
+            <!--<configuration>-->
+              <!--<pomIncludes>-->
+                <!--<pomInclude>osgi*/pom.xml</pomInclude>-->
+	      <!--</pomIncludes>-->
+	    <!--</configuration>-->
+	  <!--</plugin>-->
+	<!--</plugins>-->
+      <!--</build>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>j2ee</id>-->
+      <!--<modules>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+      <!--<properties>-->
+	<!--<invoker.skip>false</invoker.skip>-->
+	<!--<its.j2ee>no-excludes/pom.xml</its.j2ee>-->
+      <!--</properties>-->
+      <!--<build>-->
+	<!--<defaultGoal>install</defaultGoal>-->
+	<!--<plugins>-->
+          <!--<plugin>-->
+            <!--<artifactId>maven-invoker-plugin</artifactId>-->
+            <!--<configuration>-->
+              <!--<pomIncludes>-->
+                <!--<pomInclude>j2ee*/pom.xml</pomInclude>-->
+	      <!--</pomIncludes>-->
+	    <!--</configuration>-->
+	  <!--</plugin>-->
+	<!--</plugins>-->
+      <!--</build>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>single invoker test</id>-->
+      <!--<activation>-->
+        <!--<property>-->
+          <!--<name>invoker.test</name>-->
+	<!--</property>-->
+      <!--</activation>-->
+      <!--<properties>-->
+	<!--<invoker.skip>false</invoker.skip>-->
+      <!--</properties>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>jruby-jars</id>-->
+      <!--<modules>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+      <!--<build>-->
+	<!--<defaultGoal>install</defaultGoal>-->
+	<!--<pluginManagement>-->
+	  <!--<plugins>-->
+            <!--<plugin>-->
+              <!--<artifactId>maven-surefire-plugin</artifactId>-->
+              <!--<version>2.15</version>-->
+	      <!--<configuration>-->
+		<!--<skipTests>true</skipTests>-->
+	      <!--</configuration>-->
+            <!--</plugin>-->
+	  <!--</plugins>-->
+	<!--</pluginManagement>-->
+      <!--</build>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>complete</id>-->
+      <!--<modules>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+      <!--<build>-->
+	<!--<defaultGoal>install</defaultGoal>-->
+	<!--<pluginManagement>-->
+	  <!--<plugins>-->
+            <!--<plugin>-->
+              <!--<artifactId>maven-surefire-plugin</artifactId>-->
+              <!--<version>2.15</version>-->
+	      <!--<configuration>-->
+		<!--<skipTests>true</skipTests>-->
+	      <!--</configuration>-->
+            <!--</plugin>-->
+	  <!--</plugins>-->
+	<!--</pluginManagement>-->
+      <!--</build>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>rake-plugin</id>-->
+      <!--<modules>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+      <!--<build>-->
+	<!--<defaultGoal>install</defaultGoal>-->
+      <!--</build>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>dist</id>-->
+      <!--<modules>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>all</id>-->
+      <!--<modules>-->
+	<!--<module>test</module>-->
+        <!--<module>docs</module>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+      <!--<build>-->
+	<!--<defaultGoal>install</defaultGoal>-->
+      <!--</build>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>release</id>-->
+      <!--<modules>-->
+        <!--<module>maven</module>-->
+      <!--</modules>-->
+    <!--</profile>-->
+    <!--<profile>-->
+      <!--<id>snapshots</id>-->
+      <!--<activation>-->
+        <!--<file>-->
+          <!--<exists>/builds/snapshots</exists>-->
+        <!--</file>-->
+      <!--</activation>-->
+      <!--<build>-->
+        <!--<defaultGoal>deploy</defaultGoal>-->
+      <!--</build>-->
+      <!--<distributionManagement>-->
+        <!--<repository>-->
+          <!--<id>local releases</id>-->
+          <!--<url>file:/builds/snapshots/maven</url>-->
+        <!--</repository>-->
+        <!--<snapshotRepository>-->
+          <!--<id>local snapshots</id>-->
+          <!--<url>file:/builds/snapshots/maven</url>-->
+        <!--</snapshotRepository>-->
+      <!--</distributionManagement>-->
+    <!--</profile>-->
   </profiles>
   <reporting>
       <plugins>


### PR DESCRIPTION
This commit modifies some pom files to make it possible to release
the `jruby-core` and `jruby-stdlib` jars independently of the
upstream release cycle.  This is necessary so that we can
ship some critical bug fixes that have been merged upstream
but have not yet been released.

The commit also adds a README-PUPPETLABS.md file explaining the
changes and how to do the releases.
