### PR TITLE
Merge from upstream 'jruby-1_7' at 0dc6fa9

### DIFF
--- a/core/src/main/java/org/jruby/JarBootstrapMain.java
+++ b/core/src/main/java/org/jruby/JarBootstrapMain.java
@@ -49,7 +49,7 @@ package org.jruby;
  * </pre>
  */
 public class JarBootstrapMain {
-    public static final String JAR_BOOTSTRAP = "classpath:jar-bootstrap.rb";
+    public static final String JAR_BOOTSTRAP = "classpath:/jar-bootstrap.rb";
     public static void main(String[] args) {
         String[] newArgs = new String[args.length + 1];
         newArgs[0] = JAR_BOOTSTRAP;

--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -387,7 +387,14 @@ public class RubyEtc {
     public static IRubyObject getgrent(IRubyObject recv) {
         Ruby runtime = recv.getRuntime();
         try {
-            Group gr = runtime.getPosix().getgrent();
+            Group gr;
+
+            // We synchronize on this class so at least all JRuby instances in this classloader are safe.
+            // See jruby/jruby#4057
+            synchronized (RubyEtc.class) {
+                gr = runtime.getPosix().getgrent();
+            }
+
             if (gr != null) {
                 return setupGroup(recv.getRuntime(), gr);
             } else {

--- a/core/src/main/java/org/jruby/util/CompoundJarURLStreamHandler.java
+++ b/core/src/main/java/org/jruby/util/CompoundJarURLStreamHandler.java
@@ -155,13 +155,11 @@ public class CompoundJarURLStreamHandler extends URLStreamHandler {
                 try {
                     result = openEntryWithCache(path, baseInputStream, 1);
                 } catch (IOException ex) {
-                    close(baseInputStream);
-
                     throw ex;
                 } catch (RuntimeException ex) {
-                    close(baseInputStream);
-
                     throw ex;
+                } finally {
+                    close(baseInputStream);
                 }
             } else {
                 result = baseInputStream;

--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -259,6 +259,8 @@ public class JRubyClassLoader extends URLClassLoader implements ClassDefiningCla
                     }
                 } catch (IOException e) {
                     // just fall-through to the re-throw below
+                    LOG.debug("findClass IOException in getting class for url: " +
+                            classUrl + ", message: " + e.getMessage(), e);
                 }
             }
 


### PR DESCRIPTION
```
* jruby-1_7:
      Use absolute classpath URL when loading jar-bootstrap. See #4000.
      Synchronize around getgrgid call. Fixes #4057.
      Only lock Digest mutex in one place.
      Explicitly close input stream in CompoundJarURLStreamHandler
      Write a log message when findClass IOException is caught

Conflicts: None
```
