### PR TITLE
(SERVER-1408) Fixes to poms for stdlib

### DIFF
--- a/README-PUPPETLABS.md
+++ b/README-PUPPETLABS.md
@@ -5,46 +5,41 @@ for `jruby-stdlib` and `jruby-core`, independently from the upstream JRuby
 release cycle.  This was necessary in order to get access to some critical fixes
 that have been merged upstream but haven't yet been released.
 
-The files changed are:
+The file changes are limited to poms:
 
 ```
 ./pom.xml
 ./maven/pom.xml
 ./maven/jruby-stdlib/pom.xml
 ./core/pom.xml
+./lib/pom.xml
+./ext/pom.xml
+./ext/readline/pom.xml
+./ext/ripper.pom.xml
 ```
 
 The changes to those poms are limited to:
 
-* Changing the `groupId` to `puppetlabs` so that we can distinguish our artifacts.
-* Commenting out `modules` blocks, because we don't want the `mvn` tasks that we
+* Changing the `groupId` to `puppetlabs.org.jruby` so that we can distinguish our artifacts.
+* Commenting out most modules / profiles blocks, because we don't want the `mvn` tasks that we
   run to bring in any of the other components, because we don't use them in our
   builds.
-* Adding a `distributionManagement` section to each pom, so that we can specify
+* Adding a `distributionManagement` section to the parent pom, so that we can specify
   the maven artifact repository we'd like to deploy to.
 
 Technically we only really need to publish the `jruby-core` and `jruby-stdlib`
 jars, but because those have parent poms in the `org.jruby` namsepace (and because
 those parent poms will normally be versioned as SNAPSHOTs, and thus not yet
 available in public maven repositories), we need to release `puppetlabs` versions
-of those poms as well.
+of the parent poms as well.
+
+We also need to build the lib/ext modules because they contain embedded jars
+and gems that are necessary for stdlib.
 
 At the time of this writing I haven't automated any of the release process; you'll
-need to manually update the version numbers in those 4 poms, set up your
+need to manually update the version numbers in the poms, set up your
 `~/.m2/settings.xml` to provide credentials for the target repository server,
-and then run `mvn deploy` from each of the 4 subdirectories in the appropriate
-order:
-
-```
-cd .
-mvn deploy
-cd maven
-mvn deploy
-cd ../core
-mvn deploy
-cd ../maven/jruby-stdlib
-mvn deploy
-```
+and then run `mvn install` or `mvn deploy` from the root directory.
 
 It's probably wise to make sure that you are running a JDK7 version of Java
 when you do this, just to be certain that you don't end up with any published

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>puppetlabs</groupId>
+    <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
     <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
@@ -16,45 +16,6 @@
     <developerConnection>scm:git:ssh://git@github.com/jruby/jruby.git</developerConnection>
     <url>http://github.com/jruby/jruby</url>
   </scm>
-
-  <!-- __________________________________________________________________________________________ -->
-  <!-- begin custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
-  <!-- __________________________________________________________________________________________ -->
-
-  <!-- NOTE: to use any of the following you'll need to set up credentials for the
-       appropriate servers in ~/.m2/settings.xml -->
-
-  <!-- this setup would allow us to deploy to private nexus, but that would break OSS CI jobs -->
-  <!--<distributionManagement>-->
-    <!--<snapshotRepository>-->
-      <!--<id>pl-nexus-snapshots</id>-->
-      <!--<name>PL Nexus Snapshots</name>-->
-      <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
-    <!--</snapshotRepository>-->
-    <!--<repository>-->
-      <!--<id>pl-nexus-releases</id>-->
-      <!--<name>PL Nexus Releases</name>-->
-      <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
-    <!--</repository>-->
-  <!--</distributionManagement>-->
-
-  <!-- this setup deploys to clojars, which is publicly available -->
-  <distributionManagement>
-    <snapshotRepository>
-      <id>clojars</id>
-      <name>Clojars repository</name>
-      <url>https://clojars.org/repo</url>
-    </snapshotRepository>
-    <repository>
-      <id>clojars</id>
-      <name>Clojars repository</name>
-      <url>https://clojars.org/repo</url>
-    </repository>
-  </distributionManagement>
-
-  <!-- __________________________________________________________________________________________ -->
-  <!-- end custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
-  <!-- __________________________________________________________________________________________ -->
 
   <dependencies>
     <dependency>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -3,13 +3,11 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jruby</groupId>
+    <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
-  <groupId>org.jruby</groupId>
   <artifactId>jruby-ext</artifactId>
-  <version>1.7.26-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>JRuby Ext</name>

--- a/ext/readline/pom.xml
+++ b/ext/readline/pom.xml
@@ -2,9 +2,9 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jruby</groupId>
+    <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-ext</artifactId>
-    <version>1.7.26-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
   <artifactId>readline</artifactId>
   <version>1.0</version>
@@ -24,7 +24,7 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
+      <groupId>puppetlabs.org.jruby</groupId>
       <artifactId>jruby-core</artifactId>
       <version>${project.parent.version}</version>
       <scope>provided</scope>

--- a/ext/ripper/pom.xml
+++ b/ext/ripper/pom.xml
@@ -3,9 +3,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jruby</groupId>
+    <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-ext</artifactId>
-    <version>1.7.26-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
   <artifactId>ripper</artifactId>
   <version>1.7.26-SNAPSHOT</version>
@@ -25,7 +25,7 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
+      <groupId>puppetlabs.org.jruby</groupId>
       <artifactId>jruby-core</artifactId>
       <version>${project.parent.version}</version>
       <scope>provided</scope>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -10,9 +10,9 @@ DO NOT MODIFIY - GENERATED CODE
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jruby</groupId>
+    <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
   <artifactId>jruby-lib</artifactId>
   <packaging>pom</packaging>
@@ -25,9 +25,9 @@ DO NOT MODIFIY - GENERATED CODE
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.jruby</groupId>
+      <groupId>puppetlabs.org.jruby</groupId>
       <artifactId>jruby-core</artifactId>
-      <version>1.7.26-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>rubygems</groupId>

--- a/maven/jruby-stdlib/pom.xml
+++ b/maven/jruby-stdlib/pom.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>puppetlabs</groupId>
+    <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-artifacts</artifactId>
     <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
@@ -21,45 +21,6 @@
     <tesla.dump.readonly>true</tesla.dump.readonly>
     <jruby.home>${basedir}/../..</jruby.home>
   </properties>
-
-  <!-- __________________________________________________________________________________________ -->
-  <!-- begin custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
-  <!-- __________________________________________________________________________________________ -->
-
-  <!-- NOTE: to use any of the following you'll need to set up credentials for the
-       appropriate servers in ~/.m2/settings.xml -->
-
-  <!-- this setup would allow us to deploy to private nexus, but that would break OSS CI jobs -->
-  <!--<distributionManagement>-->
-  <!--<snapshotRepository>-->
-  <!--<id>pl-nexus-snapshots</id>-->
-  <!--<name>PL Nexus Snapshots</name>-->
-  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
-  <!--</snapshotRepository>-->
-  <!--<repository>-->
-  <!--<id>pl-nexus-releases</id>-->
-  <!--<name>PL Nexus Releases</name>-->
-  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
-  <!--</repository>-->
-  <!--</distributionManagement>-->
-
-  <!-- this setup deploys to clojars, which is publicly available -->
-  <distributionManagement>
-    <snapshotRepository>
-      <id>clojars</id>
-      <name>Clojars repository</name>
-      <url>https://clojars.org/repo</url>
-    </snapshotRepository>
-    <repository>
-      <id>clojars</id>
-      <name>Clojars repository</name>
-      <url>https://clojars.org/repo</url>
-    </repository>
-  </distributionManagement>
-
-  <!-- __________________________________________________________________________________________ -->
-  <!-- end custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
-  <!-- __________________________________________________________________________________________ -->
 
   <build>
     <resources>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>puppetlabs</groupId>
+    <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
     <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   </parent>
@@ -15,36 +15,11 @@
   <!-- begin custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->
   <!-- __________________________________________________________________________________________ -->
 
-  <!-- NOTE: to use any of the following you'll need to set up credentials for the
-       appropriate servers in ~/.m2/settings.xml -->
 
-  <!-- this setup would allow us to deploy to private nexus, but that would break OSS CI jobs -->
-  <!--<distributionManagement>-->
-  <!--<snapshotRepository>-->
-  <!--<id>pl-nexus-snapshots</id>-->
-  <!--<name>PL Nexus Snapshots</name>-->
-  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
-  <!--</snapshotRepository>-->
-  <!--<repository>-->
-  <!--<id>pl-nexus-releases</id>-->
-  <!--<name>PL Nexus Releases</name>-->
-  <!--<url>http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/</url>-->
-  <!--</repository>-->
-  <!--</distributionManagement>-->
-
-  <!-- this setup deploys to clojars, which is publicly available -->
-  <distributionManagement>
-    <snapshotRepository>
-      <id>clojars</id>
-      <name>Clojars repository</name>
-      <url>https://clojars.org/repo</url>
-    </snapshotRepository>
-    <repository>
-      <id>clojars</id>
-      <name>Clojars repository</name>
-      <url>https://clojars.org/repo</url>
-    </repository>
-  </distributionManagement>
+  <!-- these are the modules we need in order to build jruby-stdlib -->
+  <modules>
+    <module>jruby-stdlib</module>
+  </modules>
 
   <!-- __________________________________________________________________________________________ -->
   <!-- end custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>7</version>
   </parent>
 
-  <groupId>puppetlabs</groupId>
+  <groupId>puppetlabs.org.jruby</groupId>
   <artifactId>jruby-parent</artifactId>
   <version>1.7.26-puppetlabs-1-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -50,6 +50,15 @@
       <url>https://clojars.org/repo</url>
     </repository>
   </distributionManagement>
+
+  <!-- these are the modules we need in order to successfully build
+       jruby-core and jruby-stdlib -->
+  <modules>
+    <module>ext</module>
+    <module>core</module>
+    <module>lib</module>
+    <module>maven</module>
+  </modules>
 
   <!-- __________________________________________________________________________________________ -->
   <!-- end custom puppetlabs modifications, to deploy artifacts to a non-standard artifact repo -->


### PR DESCRIPTION
This commit does the following:
- Adds in maven 'modules' tags in appropriate places, so that we can
  now build everything we need from the root via just `mvn install`,
  rather than having to surgically do it for each relevant subproject.
- Removes unnecessary 'distributionManagement' tags from child poms,
  since they will inherit them from their parents.
- Changes groupIds from `puppetlabs` to `puppetlabs.org.jruby`, to
  more clearly distinguish these artifacts from other puppetlabs
  production / original artifacts.
- Adds in `lib` and `ext` subprojects, because without those the
  jruby-stdlib jar is missing several important files.
