### PR TITLE
(SERVER-1408) bump versions for release and tag

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-puppetlabs-rc1-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-rc1</version>
   </parent>
   <artifactId>jruby-core</artifactId>
   <packaging>jar</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-puppetlabs-rc1</version>
+    <version>1.7.26-puppetlabs-rc2-SNAPSHOT</version>
   </parent>
   <artifactId>jruby-core</artifactId>
   <packaging>jar</packaging>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-puppetlabs-rc1</version>
+    <version>1.7.26-puppetlabs-rc2-SNAPSHOT</version>
   </parent>
   <artifactId>jruby-ext</artifactId>
   <packaging>pom</packaging>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-puppetlabs-rc1-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-rc1</version>
   </parent>
   <artifactId>jruby-ext</artifactId>
   <packaging>pom</packaging>

--- a/ext/readline/pom.xml
+++ b/ext/readline/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-ext</artifactId>
-    <version>1.7.26-puppetlabs-rc1</version>
+    <version>1.7.26-puppetlabs-rc2-SNAPSHOT</version>
   </parent>
   <artifactId>readline</artifactId>
   <version>1.0</version>

--- a/ext/readline/pom.xml
+++ b/ext/readline/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-ext</artifactId>
-    <version>1.7.26-puppetlabs-rc1-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-rc1</version>
   </parent>
   <artifactId>readline</artifactId>
   <version>1.0</version>

--- a/ext/ripper/pom.xml
+++ b/ext/ripper/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-ext</artifactId>
-    <version>1.7.26-puppetlabs-rc1-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-rc1</version>
   </parent>
   <artifactId>ripper</artifactId>
   <version>1.7.26-SNAPSHOT</version>

--- a/ext/ripper/pom.xml
+++ b/ext/ripper/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-ext</artifactId>
-    <version>1.7.26-puppetlabs-rc1</version>
+    <version>1.7.26-puppetlabs-rc2-SNAPSHOT</version>
   </parent>
   <artifactId>ripper</artifactId>
   <version>1.7.26-SNAPSHOT</version>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -12,7 +12,7 @@ DO NOT MODIFIY - GENERATED CODE
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-puppetlabs-rc1-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-rc1</version>
   </parent>
   <artifactId>jruby-lib</artifactId>
   <packaging>pom</packaging>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -12,7 +12,7 @@ DO NOT MODIFIY - GENERATED CODE
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-puppetlabs-rc1</version>
+    <version>1.7.26-puppetlabs-rc2-SNAPSHOT</version>
   </parent>
   <artifactId>jruby-lib</artifactId>
   <packaging>pom</packaging>

--- a/maven/jruby-stdlib/pom.xml
+++ b/maven/jruby-stdlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-artifacts</artifactId>
-    <version>1.7.26-puppetlabs-rc1</version>
+    <version>1.7.26-puppetlabs-rc2-SNAPSHOT</version>
   </parent>
   <artifactId>jruby-stdlib</artifactId>
   <name>JRuby Stdlib</name>

--- a/maven/jruby-stdlib/pom.xml
+++ b/maven/jruby-stdlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-artifacts</artifactId>
-    <version>1.7.26-puppetlabs-rc1-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-rc1</version>
   </parent>
   <artifactId>jruby-stdlib</artifactId>
   <name>JRuby Stdlib</name>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-puppetlabs-rc1</version>
+    <version>1.7.26-puppetlabs-rc2-SNAPSHOT</version>
   </parent>
   <artifactId>jruby-artifacts</artifactId>
   <packaging>pom</packaging>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>puppetlabs.org.jruby</groupId>
     <artifactId>jruby-parent</artifactId>
-    <version>1.7.26-puppetlabs-rc1-SNAPSHOT</version>
+    <version>1.7.26-puppetlabs-rc1</version>
   </parent>
   <artifactId>jruby-artifacts</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>puppetlabs.org.jruby</groupId>
   <artifactId>jruby-parent</artifactId>
-  <version>1.7.26-puppetlabs-rc1</version>
+  <version>1.7.26-puppetlabs-rc2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>JRuby</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>puppetlabs.org.jruby</groupId>
   <artifactId>jruby-parent</artifactId>
-  <version>1.7.26-puppetlabs-rc1-SNAPSHOT</version>
+  <version>1.7.26-puppetlabs-rc1</version>
   <packaging>pom</packaging>
 
   <name>JRuby</name>


### PR DESCRIPTION
This PR contains one commit that removes the `SNAPSHOT` suffix from the `rc1` version numbers, for release to clojars.  The branch is tagged at this commit.  The second commit bumps the version numbers to `rc2-SNAPSHOT`, in case there are any additional changes that we need to integrate prior to the upstream release of JRuby 1.7.26.
